### PR TITLE
Fix parsing for achievement names + achievement search bar

### DIFF
--- a/src/Core/Achievement.cs
+++ b/src/Core/Achievement.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace BagOfTricks.Core
+{
+    internal static class Achievement
+    {
+        internal static Dictionary<string, Tuple<string, string>> invalidAchievementLookup = new()
+        {
+            { "Choose Reef-Talon for position", new("The Bastard Tribe", "Install Reef-Talon in a position of authority over the Bastard's Wound") },
+            { "Choose Wagstaff for position", new("Prince of Tidecasters", "Place Wagstaff in a position of authority over the Bastard's wound") },
+            { "Choose Jaspos for position", new("Set in Stone", "Appoint Jaspos to a position of authority over the Bastard's Wound") },
+            { "Kill Oldwalls trespassers", new("Bastard Wounder", "Slay all who would willfully trespass the Oldwalls in the Bastard's Wound") },
+            { "Complete Barik's Companion Quest", new("Change of Carapace", "Complete Barik's Companion Quest") },
+            { "Complete Lantry's companion quest", new("Truth and Reconciliation", "Complete Lantry's Companion Quest") },
+            { "Complete Verse's Companion Quest", new("Unfinished Business", "Complete Verse's Companion Quest") },
+            { "Trick Reef-Talon", new("They Sort of Deserve It...", "Trick Reef-Talon into inadvertently wiping out her loved ones in Bastard's Wound") },
+            { "Kill all Sleepless in BWound", new("Requiem for the Somnombulists", "Slay all of the Sleepless in Bastard's Wound") },
+            { "Defeat 3 encounters with sleepless ", new("Sleepless in Three Battles", "Defeat three groups of Sleepless below Bastard's Wound") },
+            { "Resolve BWound without killing resident havoc", new("Let Sleeping Abominations Lie", "Resolve the troubles of the Bastard's Wound without slaying the resident havoc") },
+            { "Distract guards by murdering bystander", new("Well Done", "Wantonly murder a bystander to distract some easily-defeated guards") },
+            { "Complete all BWound Quests and Sidequests", new("Troubleshooter", "Complete all available quests and sidequests in the Bastard's Wound") },
+            { "End with Barik trapped", new("Sloppy Seconds", "Complete the game with Barik freed out of his armor but trapped in a cage of abuse") },
+            { "Feed Verse to Nerat", new("Let the Next Verse Begin", "Complete Verse's Side-quest and have her usurp the Voices of Nerat") },
+            { "Kill a foe with slab of meat", new("Nice to Meat You", "Slay a foe with a slab of meat") },
+            { "End the game peacefully", new("Apocalypse Later", "End the conquest of the Tiers with a peaceful surrender") },
+            { "Complete BWound quests but walk away", new("Complicit Justice", "Learn of the infighting in Bastard's Wound, and do nothing to resolve it") },
+            { "Huge Miss Steak", new("I've Made a Huge Miss Steak", "Perform a Critical Miss with a slab of meat") }
+        };
+
+        public static void Parse(ref string name, ref string descr)
+        {
+            string pattern = @"\[.*?\]";
+            name = Regex.Replace(name, pattern, "");
+            descr = Regex.Replace(descr, pattern, "");
+            descr = descr.Remove(0, 1); // Remove the space at the start after removing [base] or [bwound]
+        }
+
+        public static string HighlightSearch(string input, string substring)
+        {
+            string startTag = $"<color=#{Styles.Colors.GreenHex}>";
+            string endTag = "</color>";
+
+            substring = Regex.Escape(substring);
+
+            var regexText = new Regex(substring, RegexOptions.IgnoreCase);
+            return regexText.Replace(input, $"{startTag}{substring}{endTag}");
+        }
+    }
+}

--- a/src/Core/Achievement.cs
+++ b/src/Core/Achievement.cs
@@ -22,6 +22,7 @@ namespace BagOfTricks.Core
             { "Complete all BWound Quests and Sidequests", new("Troubleshooter", "Complete all available quests and sidequests in the Bastard's Wound") },
             { "End with Barik trapped", new("Sloppy Seconds", "Complete the game with Barik freed out of his armor but trapped in a cage of abuse") },
             { "Feed Verse to Nerat", new("Let the Next Verse Begin", "Complete Verse's Side-quest and have her usurp the Voices of Nerat") },
+            { "Vision quest with Lantry", new("High as the Mountain Spire", "Share an uncomfortable moment with a party of four or more (Sirin doesn't count)")},
             { "Kill a foe with slab of meat", new("Nice to Meat You", "Slay a foe with a slab of meat") },
             { "End the game peacefully", new("Apocalypse Later", "End the conquest of the Tiers with a peaceful surrender") },
             { "Complete BWound quests but walk away", new("Complicit Justice", "Learn of the infighting in Bastard's Wound, and do nothing to resolve it") },

--- a/src/Storage/NonSerialized.cs
+++ b/src/Storage/NonSerialized.cs
@@ -13,7 +13,7 @@ namespace BagOfTricks.Storage
 
         internal static TopBarCategory s_SelectedTopBarCategory = TopBarCategory.Main;
 
-        internal static List<Tuple<string, string>> s_AchievementInfo = new();
+        internal static List<Tuple<string, string, string>> s_AchievementInfo = new();
 
         public enum TopBarCategory 
         {

--- a/src/UI/Styles.cs
+++ b/src/UI/Styles.cs
@@ -22,6 +22,8 @@ namespace BagOfTricks
 
             public static readonly Color ButtonPurpleHighlight = new(0.20f, 0.20f, 0.28f);
             public static readonly Color ButtonPurpleSelected = new(0.16f, 0.16f, 0.24f);
+
+            public static readonly string GreenHex = ColorUtility.ToHtmlStringRGB(SuccessGreen);
         }
         
         public static class GUIStyles
@@ -61,6 +63,9 @@ namespace BagOfTricks
             public static Texture2D squareTexture;
             public static Texture2D scrollThumbTexture;
             public static Texture2D scrollBackgroundTexture;
+            public static Texture2D magnifyingGlass;
+            public static Texture2D achievementRowEven;
+            public static Texture2D achievementRowOdd;
         }
 
         public static void Initialize()
@@ -81,6 +86,14 @@ namespace BagOfTricks
             string relTextRectPath = "BagOfTricks2\\UI\\Text Field Rect.png";
             fullPath = Path.Combine(pluginPath, relTextRectPath);
             Textures.rectTextFieldTexture = UI.GUIUtility.LoadTexture(fullPath);
+
+            string relMagnifyingPath = "BagOfTricks2\\UI\\Magnifying Glass.png";
+            fullPath = Path.Combine(pluginPath, relMagnifyingPath);
+            Texture2D magnifyingIcon = UI.GUIUtility.LoadTexture(fullPath);
+            Textures.magnifyingGlass = UI.GUIUtility.CreateColoredTexture(magnifyingIcon, Colors.MainPurple);
+            
+            Textures.achievementRowEven = UI.GUIUtility.CreateTexture(1, 1, Colors.LighterDark);
+            Textures.achievementRowOdd = UI.GUIUtility.CreateTexture(1, 1, Colors.Gray);
 
             GUIStyles.WindowStyle = new GUIStyle();
             GUIStyles.WindowStyle.normal.background = UI.GUIUtility.CreateTexture(1, 1, Colors.MainDark);


### PR DESCRIPTION
+ Added searchbar to Achievements section with search string highlight
+ Parse away brackets from achievement names and descriptions. Names usually begin with [base] or [bwound] and descriptions usually contain formatting. These should not be present in the achievement list.
+ Created a dictionary for achievments with the name "string_not_found" to look up their valid names and descriptions